### PR TITLE
Update font-iosevka-ttf to 26.2.1

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 26.0.1
-release    : 38
+version    : 26.2.1
+release    : 39
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v26.0.1/ttf-iosevka-26.0.1.zip : e32271df14bd7226a961fae6e1ff5b0b8f480f19a599c9fefb6fc7195f5ca4b8
+    - https://github.com/be5invis/Iosevka/releases/download/v26.2.1/ttf-iosevka-26.2.1.zip : 4145d68f681ec7c365eb5a21cb84f553dc86ccb65b3261535f37b025fa735a27
 license    : OFL-1.1
 component  : desktop.font
 summary    : Slender typeface for code, from code (default shape)

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -76,9 +76,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="38">
-            <Date>2023-08-05</Date>
-            <Version>26.0.1</Version>
+        <Update release="39">
+            <Date>2023-08-20</Date>
+            <Version>26.2.1</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
### Summary
- Fix incorrect code assignment for U+2B6E, U+2B6F, U+2B71, U+2B72
- Fix CYRILLIC CAPITAL LETTER KOMI SJE (U+050C) to follow serifs of C instead of c
- Added new characters
- Make Cyrillic Abkhasian Che respond to C's serifs
- Make lowercase Wynn respond to thorn's serifs.
- Drop APL form for U+220D as it is not used by any APL languages
- Add XH-height middle-serifed and dual-serifed variants for Eszet
- Remove duplicate variant glyphs for U+0272
- Make the top serif of Yogh (U+021C, U+021D) to follow Cyrillic Ze's variant selector
- Merge duplicate variants of t with retroflex hook
- Fix detached palatal hook on `U+01AB`` when t is both hookless/tailless and asymmetric
- Add variant selectors for lowercase Greek Pi (π) and Tau (τ)
- Make below marks to avoid bottom-right Ogoneks
- Use oval shape for Empty Set symbols to distinguish with O-Slash
- Implement leaning mark mechanism for F, L, P, b, d, h, k, p, q, r to get better mark placement
- Add variant selection for Guillemets
- Fix detached cedilla in Hookless asymmetric LATIN SMALL LETTER T WITH CEDILLA
- Fix broken hookless/tailless/asymmetric t variants in ﬅ ligature
- Remove unnecessary tailed variants for Cyrillic Shha with Descender
- Remove unnecessary lower-right serif variants for Latin Lower K with Descender
- Add italic form of CYRILLIC SMALL LETTER KOMI TJE (U+050F)
- Remove unnecessary serifed/tailed variants of italic Cyrillic Te with descender
- Remove unnecessary bottom-right serifed variants of Cyrillic Ka with descender
- Fix two off-center APL Quad characters in Quasi-proportional
- Refine shape of U+0184, U+0185
- Determine serifs of Bulgarian/Serbian De automatically when g is double-storey.
- Fix leaning marks of LATIN SMALL LETTER T WITH CEDILLA
- Fix the dimensions of wide geometric shapes in quasi-proportional

### Test Plan

render text with the font

### Checklist

- [X] Package was built and tested against unstable
