### PR TITLE
font-iosevka-ttf: update to 26.2.2

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,9 @@
 name       : font-iosevka-ttf
-version    : 26.2.1
-release    : 39
+version    : 26.2.2
+release    : 40
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v26.2.1/ttf-iosevka-26.2.1.zip : 4145d68f681ec7c365eb5a21cb84f553dc86ccb65b3261535f37b025fa735a27
+    - https://github.com/be5invis/Iosevka/releases/download/v26.2.2/ttf-iosevka-26.2.2.zip : 0c27e45cca3ee529695155f1236335111ef1d6821abc84939ef60fe1815b9abb
+homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font
 summary    : Slender typeface for code, from code (default shape)

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -1,6 +1,7 @@
 <PISI>
     <Source>
         <Name>font-iosevka-ttf</Name>
+        <Homepage>https://typeof.net/Iosevka</Homepage>
         <Packager>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>
@@ -76,9 +77,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="39">
-            <Date>2023-08-20</Date>
-            <Version>26.2.1</Version>
+        <Update release="40">
+            <Date>2023-08-31</Date>
+            <Version>26.2.2</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
### Summary
- Added characters
- Add support for specialized Vietnamese dual diacritics
- Make bowl height of Cyrillic Yat and Tall Yat (U+0463, U+1C67) consistent
- Remove duplicate lower-right serif variants of H with descender
- Fix toothless variants of LATIN SMALL LETTER B WITH HOOK (U+0253)
- Always use closed variants for LATIN CAPITAL LETTER R WITH STROKE (U+024C).
- Optimize shape of LATIN {SMALL CAPITAL|MODIFIER LETTER CAPITAL} BARRED B (U+1D03,U+1D2F)
 
### Test Plan

render text with the font

### Checklist

- [X] Package was built and tested against unstable
