### PR TITLE
font-iosevka-ttf: update to 26.3.3

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : font-iosevka-ttf
-version    : 26.3.2
-release    : 41
+version    : 26.3.3
+release    : 42
 source     :
-    - https://github.com/be5invis/Iosevka/releases/download/v26.3.2/ttf-iosevka-26.3.2.zip : 681fec18f0c76a75b46d04b57717d5b0a0d86f657fc9b04e2b486a8479901c21
+    - https://github.com/be5invis/Iosevka/releases/download/v26.3.3/ttf-iosevka-26.3.3.zip : 8722ba67202d684fefbac873b5dd49af4a0f9edfab424d1ecf3113d123c58f3a
 homepage   : https://typeof.net/Iosevka
 license    : OFL-1.1
 component  : desktop.font

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -77,9 +77,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="41">
-            <Date>2023-09-06</Date>
-            <Version>26.3.2</Version>
+        <Update release="42">
+            <Date>2023-09-14</Date>
+            <Version>26.3.3</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
### Summary
- Changed variant names
- Added barred-serifed and barred-earless-rounded variants for Greek Alpha (α).
- Removed serifs in U+0320
- Harmonize dot sizes in ellipsis shapes
- Make italic Cyrillic Small Pe with Middle Hook (U+04A7) follow variants of n
- Add leaning mark anchors for Thorn (Þ/þ)
- Remove duplicate serif variants for U+0266 and U+2C74.
- Allow cursive variants of turned v (U+028C) to match turned w (U+028D).
- Allow turned tail variants for Mathematical Sans-Serif y (U+1D5D2).
- Only allow toothed variants of d with palatal hook (U+1D81) to match a and u with hook attachments (U+1D8F, U+1D99).
- Fix variant selection for U+1D4A, U+1DEA, and U+2094.
- Remove bottom serifs in LATIN {CAPITAL|SMALL} LETTER INSULAR R (U+A782, U+A783).

### Test Plan
render text with the font

### Checklist
- [X] Package was built and tested against unstable
